### PR TITLE
Extend directive plugin to work on all operations

### DIFF
--- a/.changeset/long-corners-hope.md
+++ b/.changeset/long-corners-hope.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/apollo-gateway-directives": minor
+---
+
+Add support for applying directives on all operation types


### PR DESCRIPTION
The current implementation of the gateway-directives plugin silently ignores any directive applied to non-mutation operations. This  is currently not communicated clearly to the implementer.

This PR extends the gateway-directives plugin to allow directives to work on any operation type, rather than only on mutation fields. This leaves the decision whether it is desireable to apply directives to non-mutation fields up to the implementer.